### PR TITLE
feat: Add Bamboo.TestAdapter.forward/2

### DIFF
--- a/lib/bamboo/adapters/test_adapter.ex
+++ b/lib/bamboo/adapters/test_adapter.ex
@@ -19,6 +19,71 @@ defmodule Bamboo.TestAdapter do
 
   @behaviour Bamboo.Adapter
 
+  use GenServer
+
+  @doc false
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  @doc """
+  Forward messages sent in `from_pid` to `to_pid`. This provides a way to
+  write tests that send emails in other processes without resorting to shared
+  mode (which cannot be used with async tests).
+
+  To enable this feature, the `Bamboo.TestAdapter` GenServer must be started in
+  your `test/test_helper.exs`:
+
+      {:ok, _} = Supervisor.start_link([Bamboo.TestAdapter], strategy: :one_for_one)
+
+  You must then have a way to find out the pid of the process that is sending
+  the email and forward it to the process that is running your test.
+
+  For example, when running browser tests with Pheonix, you can configure
+  [Phoenix.Ecto.SQL.Sandbox](https://hexdocs.pm/phoenix_ecto/4.3.0/Phoenix.Ecto.SQL.Sandbox.html#content)
+  to achieve this.
+
+  In `config/test.exs`:
+
+      config :your_app, :sandbox, Ecto.Adapters.SQL.Sandbox
+
+  In `lib/your_app_web/endpoint.ex`:
+
+      if sandbox = Application.get_env(:your_app, :sandbox) do
+        plug Phoenix.Ecto.SQL.Sandbox, sandbox: sandbox
+      end
+
+  Now add `test/support/sandbox.ex`:
+
+      defmodule YourApp.Sandbox do
+        def allow(repo, owner_pid, child_pid) do
+          # Delegate to the Ecto sandbox
+          Ecto.Adapters.SQL.Sandbox.allow(repo, owner_pid, child_pid)
+
+          # Forward emails back to the test process
+          Bamboo.TestAdapter.forward(child_pid, owner_pid)
+        end
+      end
+  """
+  def forward(from_pid, to_pid) do
+    :ok = GenServer.call(__MODULE__, {:put_forward, from_pid, to_pid})
+  end
+
+  @doc false
+  def init(:ok) do
+    {:ok, %{forwards: %{}}}
+  end
+
+  @doc false
+  def handle_call({:put_forward, from_pid, to_pid}, _from, state) do
+    {:reply, :ok, put_in(state.forwards[from_pid], to_pid)}
+  end
+
+  @doc false
+  def handle_call({:get_forward, from_pid}, _from, state) do
+    {:reply, state.forwards[from_pid], state}
+  end
+
   @doc false
   def deliver(email, _config) do
     email = clean_assigns(email)
@@ -27,7 +92,13 @@ defmodule Bamboo.TestAdapter do
   end
 
   defp test_process do
-    Application.get_env(:bamboo, :shared_test_process) || self()
+    Application.get_env(:bamboo, :shared_test_process) || forward_pid() || self()
+  end
+
+  defp forward_pid do
+    if GenServer.whereis(__MODULE__) do
+      GenServer.call(__MODULE__, {:get_forward, self()})
+    end
   end
 
   def handle_config(config) do


### PR DESCRIPTION
This provides a way to receive emails from other processes without
resorting to shared mode and synchronous tests.

For background, this builds on some work that I did to allow Wallaby
tests to play nicely with Mox, while still allowing the tests to be
async. I wrote about it here:

https://jonleighton.name/2021/asynchronous-browser-tests-with-phoenix/

And then contributed some docs to Wallaby about the setup here:

https://github.com/elixir-wallaby/wallaby/pull/592

This commit basically implements a kind of Mox.allow/3 function for
Bamboo.TestAdapter.

Note that I’ve changed the order of the arguments for this
Bamboo.TestAdapter.forward/2 function. For Mox.allow/3, the owner_pid
comes first:

    Mox.allow(MyMock, owner_pid, child_pid)

But for Bamboo.TestAdapter.forward/2, the child_pid comes first:

    Bamboo.TestAdapter.forward(child_pid, owner_pid)

My reasoning is that in the first example we’re allowing the child_pid
to access mocks defined by the owner pid. But in the second example,
we’re forwarding emails FROM the child_pid TO the owner_pid. So this
order of arguments seemed to make sense to me, but may be slightly
confusing.