### PR TITLE
Remove CDN & Implement in-use css from CDN into internal css

### DIFF
--- a/lib/bamboo/plug/sent_email_viewer/email_not_found.html.eex
+++ b/lib/bamboo/plug/sent_email_viewer/email_not_found.html.eex
@@ -5,10 +5,10 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
     <title>Sent Emails</title>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/4.0.0/normalize.css" charset="utf-8">
     <style>
       html {
         height: 100%;
+        -webkit-text-size-adjust: 100%;
       }
 
       body {

--- a/lib/bamboo/plug/sent_email_viewer/index.html.eex
+++ b/lib/bamboo/plug/sent_email_viewer/index.html.eex
@@ -5,8 +5,12 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
     <title>Sent Email</title>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/4.0.0/normalize.css" charset="utf-8">
     <style>
+      html {
+        height: 100%;
+        -webkit-text-size-adjust: 100%;
+      }
+
       body {
         min-width: 800px;
         font-size: 15px;

--- a/lib/bamboo/plug/sent_email_viewer/no_emails.html.eex
+++ b/lib/bamboo/plug/sent_email_viewer/no_emails.html.eex
@@ -5,10 +5,10 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
     <title>Sent Email</title>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/4.0.0/normalize.css" charset="utf-8">
     <style>
       html {
         height: 100%;
+        -webkit-text-size-adjust: 100%;
       }
 
       body {


### PR DESCRIPTION
Created this pull request in response to issue #517. Removed CDN from all the files serving UI for SentEmailViewer and implemented css being in use from CDN into internal css. 