### PR TITLE
docs: Adds Mailtrap Sandbox and Sending adapters to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,7 @@ add a new adapter to the list.
 - `Bamboo.SesAdapter` - See [kalys/bamboo_ses](https://github.com/kalys/bamboo_ses).
 - `Bamboo.SMTPAdapter` - See [fewlinesco/bamboo_smtp](https://github.com/fewlinesco/bamboo_smtp).
 - `Bamboo.SparkPostAdapter` - See [andrewtimberlake/bamboo_sparkpost](https://github.com/andrewtimberlake/bamboo_sparkpost).
+- `Bamboo.MailtrapSendingAdapter`, `Bamboo.MailtrapSandboxAdapter` - See [railsware/mailtrap-elixir](https://github.com/railsware/mailtrap-elixir)
 
 ## Contributing
 


### PR DESCRIPTION
This PR adds Mailtrap.io's Sandbox and Sending adapters to the list of adapters in README.md.