### PR TITLE
Fix Elixir 1.17 warning about function call without parens

### DIFF
--- a/lib/bamboo/mailer.ex
+++ b/lib/bamboo/mailer.ex
@@ -304,7 +304,7 @@ defmodule Bamboo.Mailer do
 
   defp validate_attachment_support(_email, adapter) do
     if Code.ensure_loaded?(adapter) && function_exported?(adapter, :supports_attachments?, 0) &&
-         adapter.supports_attachments? do
+         adapter.supports_attachments?() do
       :ok
     else
       {:error, "the #{adapter} does not support attachments yet."}


### PR DESCRIPTION
In e3d20799fdc07a67acb068bff65bbe4e07c41e88 I've fixed a warning about invoking a function without parentheses. It shows at run-time and looks like this:
```
warning: using map.field notation (without parentheses) to invoke function Bamboo.TestAdapter.supports_attachments?() is deprecated, you must add parentheses instead: remote.function()
  (bamboo 2.3.0) lib/bamboo/mailer.ex:307: Bamboo.Mailer.validate_attachment_support/2
  (bamboo 2.3.0) lib/bamboo/mailer.ex:289: Bamboo.Mailer.validate_and_normalize/2
  (bamboo 2.3.0) lib/bamboo/mailer.ex:240: Bamboo.Mailer.deliver_later/3
```