### PR TITLE
feat!: Implement before_interceptor that runs before stripping the recipients with the formatter

### DIFF
--- a/lib/bamboo/mailer.ex
+++ b/lib/bamboo/mailer.ex
@@ -203,8 +203,8 @@ defmodule Bamboo.Mailer do
 
   @doc false
   def deliver_now(adapter, email, config, opts) do
-    with {:ok, email} <- validate_and_normalize(email, adapter),
-         %Bamboo.Email{blocked: false} = email <- apply_interceptors(email, config) do
+    with %Bamboo.Email{blocked: false} = email <- apply_interceptors(email, config),
+         {:ok, email} <- validate_and_normalize(email, adapter) do
       if empty_recipients?(email) do
         debug_unsent(email)
 
@@ -244,8 +244,8 @@ defmodule Bamboo.Mailer do
 
   @doc false
   def deliver_later(adapter, email, config) do
-    with {:ok, email} <- validate_and_normalize(email, adapter),
-         %Bamboo.Email{blocked: false} = email <- apply_interceptors(email, config) do
+    with %Bamboo.Email{blocked: false} = email <- apply_interceptors(email, config),
+         {:ok, email} <- validate_and_normalize(email, adapter) do
       if empty_recipients?(email) do
         debug_unsent(email)
       else

--- a/test/support/deny_list_interceptor.ex
+++ b/test/support/deny_list_interceptor.ex
@@ -3,11 +3,19 @@ defmodule Bamboo.DenyListInterceptor do
 
   @deny_list ["blocked@blocked.com"]
 
-  def call(email) do
-    if Enum.any?(email.to, &(elem(&1, 1) in @deny_list)) do
+  def call(%{to: recipients} = email) when is_list(recipients) do
+    if Enum.any?(recipients, &(&1 in @deny_list)) do
       Bamboo.Email.block(email)
     else
       email
     end
+  end
+
+  def call(%{to: recipient} = email) when recipient in @deny_list do
+    Bamboo.Email.block(email)
+  end
+
+  def call(email) do
+    email
   end
 end


### PR DESCRIPTION
I would like to use the interceptor to detect the preferences of the rich struct that is set as a receiver on the 'to:'

The (implemented) formatter strips all info from this struct and just set a {name, email} tuple instead which I cannot use at the interceptor level anymore.

I decided to swap them: interceptor first normalization and validation second - can't think of a reason this would result in unwanted behavior. 

Could you take this under consideration?