### PR TITLE
Add support for content_id in SendgridAdapter

### DIFF
--- a/lib/bamboo/adapters/send_grid_adapter.ex
+++ b/lib/bamboo/adapters/send_grid_adapter.ex
@@ -397,15 +397,33 @@ defmodule Bamboo.SendGridAdapter do
       attachments
       |> Enum.reverse()
       |> Enum.map(fn attachment ->
-        %{
-          filename: attachment.filename,
-          type: attachment.content_type,
-          content: Base.encode64(attachment.data)
-        }
+        maybe_append_content_id(
+          %{
+            filename: attachment.filename,
+            type: attachment.content_type,
+            content: Base.encode64(attachment.data),
+            disposition: attachment_disposition(attachment)
+          },
+          attachment
+        )
       end)
 
     Map.put(body, :attachments, transformed)
   end
+
+  defp maybe_append_content_id(map, %{content_id: nil}) do
+    map
+  end
+
+  defp maybe_append_content_id(map, %{content_id: content_id}) do
+    Map.put(map, :content_id, content_id)
+  end
+
+  defp attachment_disposition(%Bamboo.Attachment{content_id: cid}) when not is_nil(cid) do
+    "inline"
+  end
+
+  defp attachment_disposition(_), do: "attachment"
 
   defp put_addresses(body, _, []), do: body
 


### PR DESCRIPTION
Introduces support for content_id so that inline images in e-mails can be send and referenced from HTML content of the e-mail, when using SendGrid Adapter.